### PR TITLE
changed container to section-container

### DIFF
--- a/IndxStyles.css
+++ b/IndxStyles.css
@@ -67,7 +67,7 @@ body{
 
 
 /********section container**********/
-.section .container{
+.section .section-container{
     /*border: red 2px;*/
     display: flex;
     justify-content: center;


### PR DESCRIPTION
Only changes `.container` to .`section-container` in the css file since you are referting to the class as `.section-container` in the HTML file.